### PR TITLE
test t/13-filter_datetime.t failed.

### DIFF
--- a/t/13-filter_datetime.t
+++ b/t/13-filter_datetime.t
@@ -84,7 +84,7 @@ SKIP: {
     eval 'use Date::Calc::Object';
     skip 'Date::Calc::Object not available', 2 if $@;
 
-    my $d = Date::Calc::Object->localtime( [1234567890] );
+    my $d = Date::Calc::Object->localtime( 1234567890 );
     my $string = $d->string(2);
     is( p($d), $string, 'Date::Calc::Object' );
     my @list = ($d, { foo => 1 });


### PR DESCRIPTION
If "Date::Calc::Object" installed, t/13-filter_datetime.t fails.
Date::Calc::Object->localtime receives scalar value.
