### PR TITLE
Documentation tips

### DIFF
--- a/lib/Data/Printer.pm
+++ b/lib/Data/Printer.pm
@@ -1153,12 +1153,13 @@ Add these lines to your C<.perldb> file:
 
     $DB::alias{px} = 's/px/DB::px/';
     sub px {
+        my $expr = shift;
         require Data::Printer;
-        print Data::Printer::p( \$_[0] );
+        print Data::Printer::p($expr);
     }
 
-Now you can use C<px> inside the Perl debugger to dump expressions using
-Data::Printer.
+Now, inside the Perl debugger, you can pass as reference to C<px> expressions
+to be dumped using Data::Printer.
 
 =head2 Circumventing prototypes
 


### PR DESCRIPTION
Automatic loading tip improvement: use require to conditionally load Data::Printer and only add it to modules, preventing messing up the symbol table.

New tip on using Data::Printer inside the Perl debugger.
