### PR TITLE
Changed link in Documentation

### DIFF
--- a/lib/Data/Printer.pm
+++ b/lib/Data/Printer.pm
@@ -1500,7 +1500,7 @@ previous dumping function.
 
 If, however, you want a really unified approach where you can easily
 flip between debugging outputs, use L<Any::Renderer> and its plugins,
-like L<< Any::Renderer::Data::Printer|https://github.com/kmcgrath/Any-Renderer-Data-Printer >>.
+like L<Any::Renderer::Data::Printer>.
 
 =head2 Printing stack traces with arguments expanded using Data::Printer
 


### PR DESCRIPTION
The link to GitHub for Any::Renderer::Data::Printer was out of date and since the module in question is on the CPAN it's probably better to link in a more conventional way anyway?
