### PR TITLE
Escape nulls in strings?

### DIFF
--- a/lib/Data/Printer.pm
+++ b/lib/Data/Printer.pm
@@ -303,6 +303,7 @@ sub SCALAR {
         $string .= colored($$item, $p->{color}->{'number'});
     }
     else {
+        $$item =~ s/\0/\\0/g;
         $string .= colored(qq["$$item"], $p->{color}->{'string'});
     }
 


### PR DESCRIPTION
Otherwise, we can't tell the difference between a blank string and a string with nulls in it. I tried doing it with

`use Data::Printer filters => {SCALAR => sub { ${$_[0]} =~ s/\0/\\0/gr;}};`

but then I still wanted to call the original SCALAR filter.
