### PR TITLE
Make possible to use custom rc files

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -21,6 +21,7 @@ my %options = (
         'Hash::FieldHash' => 0,
         'File::HomeDir'   => 0.91, # introduces File::HomeDir::Test
         'File::Spec'      => 0,
+        'File::Temp'      => 0,
         'Fcntl'           => 0,
     },
     META_MERGE      => {

--- a/lib/Data/Printer.pm
+++ b/lib/Data/Printer.pm
@@ -101,10 +101,17 @@ sub import {
     # the RC file overrides the defaults,
     # (and we load it only once)
     unless( exists $properties->{_initialized} ) {
-        my $file = File::Spec->catfile(
-            File::HomeDir->my_home,
-            '.dataprinter'
-        );
+        my $file;
+        if (defined $args && !ref $args) {
+            $file = $args;
+        }
+        else {
+            $file = File::Spec->catfile(
+                File::HomeDir->my_home,
+                '.dataprinter'
+            );
+        }
+
         if (-e $file) {
             if ( open my $fh, '<', $file ) {
                 my $rc_data;

--- a/t/16.2-custom_rc_file.t
+++ b/t/16.2-custom_rc_file.t
@@ -1,0 +1,22 @@
+use strict;
+use warnings;
+use Test::More;
+
+my $file;
+BEGIN {
+    use_ok ('File::Temp');
+
+    $file = File::Temp->new()
+        or plan skip_all => "error creating temporary rc file: $!";
+    $file->print('{colored => 0, hash_separator => " ><(((o> "}')
+        or plan skip_all => "error writing to temporary rc file: $!";
+    $file->close();
+
+    use_ok ('Data::Printer', $file->filename());
+};
+
+my %hash = ( key => 'value' );
+
+is( p(%hash), qq[{$/    key ><(((o> "value"$/}], 'custom rc file works');
+
+done_testing;


### PR DESCRIPTION
Today I found very unhandy that DDP does not allow to specify a custom rc file but ~/.dataprinter only. For example you are debugging a script that runs under a server that, in turn, runs under non-your-user account. Even more---that user does not has a home dir. at all.
And now just 'use DDP q(/home/mvuets/.dataprinter);' and voilà!
