### PR TITLE
Fixed some warnings when not using colors

### DIFF
--- a/lib/Data/Printer.pm
+++ b/lib/Data/Printer.pm
@@ -226,7 +226,7 @@ sub _data_printer {
         delete $ENV{ANSI_COLORS_DISABLED};
     }
 
-    my $out = color('reset');
+    my $out = color('reset') || '';
 
     if ( $p->{caller_info} and $p->{_depth} == 0 ) {
         $out .= _get_info_message($p);
@@ -323,8 +323,8 @@ sub SCALAR {
 sub _escape_chars {
     my ($str, $orig_color, $p) = @_;
 
-    $orig_color   = color( $orig_color );
-    my $esc_color = color( $p->{color}{escaped} );
+    $orig_color   = color( $orig_color )          || '';
+    my $esc_color = color( $p->{color}{escaped} ) || '';
 
     my $escape_chars = 1;
     if (exists $p->{escape_chars}) {


### PR DESCRIPTION
If I explicitly turn colors off when using Data::Printer, I currently get some undefined warnings.  This pull request fixes that.
