### PR TITLE
New option 'end_comma'

### DIFF
--- a/t/33-end_comma.t
+++ b/t/33-end_comma.t
@@ -1,0 +1,37 @@
+use strict;
+use warnings;
+
+use Test::More tests => 1;
+BEGIN {
+    $ENV{ANSI_COLORS_DISABLED} = 1;
+    delete $ENV{DATAPRINTERRC};
+    use File::HomeDir::Test;  # avoid user's .dataprinter
+};
+
+use Data::Printer end_comma => 1;
+
+my $structure = [
+    1,
+    2,
+    {
+        a          => 1,
+        b          => 2,
+        long_line  => 3,
+    },
+];
+
+my $end_comma_output = '\ [
+    [0] 1,
+    [1] 2,
+    [2] {
+        a           1,
+        b           2,
+        long_line   3,
+    },
+]';
+
+is(
+    p($structure),
+    $end_comma_output,
+    'Got correct structure with end_comma = 1',
+);


### PR DESCRIPTION
I have configured DDP to output data the same as does Data::Dumper.
I need the ability to copy DDP output and paste in in the code. I'm using
DDP insted of Data::Dumper because of 3 great thing: color output, caller
info and pretty and simple code avaliable on github.

Here is my ~/.dataprinter:

```
{   
    caller_info    => 1,
    use_prototypes => 0,
    hash_separator => '  => ',
    index          => 0,
    return_value   => 'void',
}   
```

The output of the p() is something like:

```
Printing in line 12 of a.pl:
[   
    1,  
    2,  
    {   
        a          => 1,
        b          => 2,
        long_line  => 3
    }   
]   
```

But there is one thing that annoys me. Sometimes I need to modify the 
structure I've copied from DDP output. I add some element to the hash or
array, but I foget inserting comma on the previously last line.

This patch added new option 'end_comma'. If it is true it will place commas
after the last elemets of hash and array.
