### PR TITLE
DDP was warning when dumping refs to unopened or closed file handles

### DIFF
--- a/lib/Data/Printer.pm
+++ b/lib/Data/Printer.pm
@@ -596,7 +596,7 @@ sub GLOB {
     # implement some of these flags (maybe not even
     # fcntl() itself, so we must wrap it.
     my $flags;
-    eval { $flags = fcntl($$item, F_GETFL, 0) };
+    eval { no warnings qw( unopened closed ); $flags = fcntl($$item, F_GETFL, 0) };
     if ($flags) {
         $extra .= ($flags & O_WRONLY) ? 'write-only'
                 : ($flags & O_RDWR)   ? 'read/write'


### PR DESCRIPTION
This just suppresses two warnings that don't otherwise indicate problems.  In the future maybe check the "opened" flag? I'm not entirely sure one would distinguish between "closed" and "unopened" nor if one would want to.
