### PR TITLE
Add support for FORMAT and LVALUE refs

### DIFF
--- a/lib/Data/Printer.pm
+++ b/lib/Data/Printer.pm
@@ -62,6 +62,8 @@ my $properties = {
         'code'        => 'green',
         'glob'        => 'bright_cyan',
         'vstring'     => 'bright_blue',
+        'lvalue'      => 'bright_white',
+        'format'      => 'bright_cyan',
         'repeated'    => 'white on_red',
         'caller_info' => 'bright_cyan',
         'weak'        => 'cyan',
@@ -83,6 +85,9 @@ my $properties = {
         _depth       => 0,        # used internally
     },
     'filters' => {
+        # The IO ref type isn't supported as you can't actually create one,
+        # any handle you make is automatically blessed into an IO::* object,
+        # and those are separately handled.
         SCALAR  => [ \&SCALAR   ],
         ARRAY   => [ \&ARRAY    ],
         HASH    => [ \&HASH     ],
@@ -90,6 +95,8 @@ my $properties = {
         CODE    => [ \&CODE     ],
         GLOB    => [ \&GLOB     ],
         VSTRING => [ \&VSTRING  ],
+        LVALUE  => [ \&LVALUE ],
+        FORMAT  => [ \&FORMAT ],
         Regexp  => [ \&Regexp   ],
         -unknown=> [ \&_unknown ],
         -class  => [ \&_class   ],
@@ -583,6 +590,21 @@ sub VSTRING {
     return $string;
 }
 
+sub FORMAT {
+    my ($item, $p) = @_;
+    my $string = '';
+    $string .= colored("FORMAT", $p->{color}->{'format'});
+    return $string;
+}
+
+sub LVALUE {
+    my ($item, $p) = @_;
+    my $string = '';
+    $string .= colored("LVALUE", $p->{color}->{'format'});
+    $string .= "  ";
+    $string .= SCALAR( $item, $p );
+    return $string;
+}
 
 sub GLOB {
     my ($item, $p) = @_;

--- a/t/37-format.t
+++ b/t/37-format.t
@@ -1,0 +1,27 @@
+use strict;
+use warnings;
+
+BEGIN {
+    $ENV{ANSI_COLORS_DISABLED} = 1;
+    delete $ENV{DATAPRINTERRC};
+    use File::HomeDir::Test;  # avoid user's .dataprinter
+
+    use Test::More;
+    use Data::Printer;
+
+}
+
+format TEST =
+.
+
+my $form = *TEST{FORMAT};
+my $test_name = "FORMAT refs";
+eval {
+    is( p($form), 'FORMAT', $test_name );
+};
+if ($@) {
+    fail( $test_name );
+    diag( $@ );
+}
+
+done_testing();

--- a/t/38-lvalue.t
+++ b/t/38-lvalue.t
@@ -1,0 +1,24 @@
+use strict;
+use warnings;
+
+BEGIN {
+    $ENV{ANSI_COLORS_DISABLED} = 1;
+    delete $ENV{DATAPRINTERRC};
+    use File::HomeDir::Test;  # avoid user's .dataprinter
+
+    use Test::More;
+    use Data::Printer;
+
+}
+
+my $scalar = \substr( "abc", 2);
+my $test_name = "LVALUE refs";
+eval {
+    is( p($scalar), 'LVALUE  "c"', $test_name );
+};
+if ($@) {
+    fail( $test_name );
+    diag( $@ );
+}
+
+done_testing();


### PR DESCRIPTION
This adds explicit display support for FORMAT and LVALUE refs.  FORMAT refs are, as best as I can tell, opaque, so they're just displayed as "FORMAT".  LVALUE refs shown as "LVALUE" followed by the normal scalar ref handling, eg:
`my $foo = substr("abc",2);`
`p $foo;`
Will result in:
`LVALUE  "c"`
