### PR TITLE
The string quotes are printed without color

### DIFF
--- a/lib/Data/Printer.pm
+++ b/lib/Data/Printer.pm
@@ -324,7 +324,7 @@ sub SCALAR {
     else {
         my $val = _escape_chars($$item, $p->{color}{string}, $p);
 
-        $string .= colored(qq["$val"], $p->{color}->{'string'});
+        $string .= qq["] . colored($val, $p->{color}->{'string'}) . qq["];
     }
 
     $string .= ' ' . colored('(TAINTED)', $p->{color}->{'tainted'})


### PR DESCRIPTION
Before:

![before](https://dl.dropbox.com/u/2182575/smth/Selection_006.png)

After:

![after](https://dl.dropbox.com/u/2182575/smth/Selection_007.png)

(the difference is the color of the external quotes)
