### PR TITLE
Fixing failing tests to work with DATAPRINTERRC

### DIFF
--- a/t/20-handles.t
+++ b/t/20-handles.t
@@ -11,12 +11,12 @@ BEGIN {
     use Test::More;
     use Fcntl;
 
-    use Data::Printer;
-
     $filename = File::Spec->catfile(
         File::HomeDir->my_home, 'test_file.dat'
     );
 };
+
+use Data::Printer;
 
 if ( open $var, '>', $filename ) {
     my $str = p $var;

--- a/t/26-tainted.t
+++ b/t/26-tainted.t
@@ -17,8 +17,9 @@ BEGIN {
     delete $ENV{DATAPRINTERRC};
     use File::HomeDir::Test;  # avoid user's .dataprinter
     use_ok ('Term::ANSIColor');
-    use_ok ('Data::Printer', colored => 1);
 };
+
+use Data::Printer colored => 1;
 
 is(
     p($path),

--- a/t/35-vstrings.t
+++ b/t/35-vstrings.t
@@ -7,9 +7,9 @@ BEGIN {
     use File::HomeDir::Test;  # avoid user's .dataprinter
 
     use Test::More;
-    use Data::Printer;
-
 }
+
+use Data::Printer;
 
 plan skip_all => 'Older perls do not have VSTRING support' if $] < 5.010;
 my $scalar = v1.2.3;

--- a/t/36-valign.t
+++ b/t/36-valign.t
@@ -8,8 +8,9 @@ BEGIN {
     $ENV{ANSI_COLORS_DISABLED} = 1;
     delete $ENV{DATAPRINTERRC};
     use File::HomeDir::Test;  # avoid user's .dataprinter
-    use Data::Printer;
 };
+
+use Data::Printer;
 
 my $var = { q[foo bar],2,3,4};
 

--- a/t/37-format.t
+++ b/t/37-format.t
@@ -7,9 +7,10 @@ BEGIN {
     use File::HomeDir::Test;  # avoid user's .dataprinter
 
     use Test::More;
-    use Data::Printer;
 
 }
+
+use Data::Printer;
 
 format TEST =
 .

--- a/t/38-lvalue.t
+++ b/t/38-lvalue.t
@@ -7,9 +7,9 @@ BEGIN {
     use File::HomeDir::Test;  # avoid user's .dataprinter
 
     use Test::More;
-    use Data::Printer;
-
 }
+
+use Data::Printer;
 
 my $scalar = \substr( "abc", 2);
 my $test_name = "LVALUE refs";


### PR DESCRIPTION
In my environment I have set up DATAPRINTERRC=
/home/bessarabov/felix/tilde/.dataprinter (you can see the content of this
file: https://gist.github.com/4216269)

With this ENV variable set I had some tests failing. Now I have managed to
find why it happens. The problem is with the BEGIN section in tests. If
`use DDP` is in the BEGIN section of the test file then the import() method
from file Data/Printer.pm is executed before the things written in the test
BEGIN section.

To prevent tests from failng I have moved `use DDP` out ouf BEGIN section. And
now all my tests pass.

I think if you accept this solution other test files also need to be fixed:
with my rc file they pass, but I think that the otther rc file can cause them
to fail.
