### PR TITLE
More accurate separation numbers from strings

### DIFF
--- a/lib/Data/Printer.pm
+++ b/lib/Data/Printer.pm
@@ -320,7 +320,7 @@ sub SCALAR {
     if (not defined $$item) {
         $string .= colored('undef', $p->{color}->{'undef'});
     }
-    elsif (Scalar::Util::looks_like_number($$item)) {
+    elsif (_is_number($$item)) {
         $string .= colored($$item, $p->{color}->{'number'});
     }
     else {
@@ -339,6 +339,30 @@ sub SCALAR {
     }
 
     return $string;
+}
+
+sub _is_number {
+    my ($maybe_a_number) = @_;
+
+    # Scalar values that start from zero is strings, but not numbers.
+    # You can write `my $foo = 0123`, but then `$foo` will be 83,
+    # (numbers starting with zero is octal integers)
+    return '' if $maybe_a_number =~ /^-?0[0-9]/;
+
+    my $is_number = $maybe_a_number =~ m/
+        ^
+        -?          # number can start with minus, but can't start with plus
+                    # is scalar starts with plus it is not number
+
+        [0-9-]+     # then there should be some numbers
+
+        ( \. [0-9]+ )?      # there can be decimal part, which is optional
+
+        ( e [+-] [0-9]+ )?  # then there can be optional exponential notation part
+        $
+    /x;
+
+    return $is_number;
 }
 
 sub _escape_chars {

--- a/t/43-_is_number.t
+++ b/t/43-_is_number.t
@@ -1,0 +1,53 @@
+use strict;
+use warnings;
+
+use Test::More;
+BEGIN {
+    $ENV{ANSI_COLORS_DISABLED} = 1;
+    delete $ENV{DATAPRINTERRC};
+    use File::HomeDir::Test;  # avoid user's .dataprinter
+};
+
+use Data::Printer;
+
+pass('Loaded ok');
+
+my @numbers = (
+    -1,
+    0,
+    1,
+    1.23,
+    1.23e+38,
+    1.23e-38,
+    123,
+);
+
+foreach my $number (@numbers) {
+    ok(
+        Data::Printer::_is_number($number),
+        "_is_number('$number') return true",
+    );
+}
+
+my @strings = (
+    "",
+    "+0123",
+    "+1",
+    "-0123",
+    "0 but true",
+    "0123",
+    "Inf",
+    "Infinity",
+    "NaN",
+    "abc",
+    '1_000',
+);
+
+foreach my $not_a_number (@strings) {
+    ok(
+        not(Data::Printer::_is_number($not_a_number)),
+        "_is_number('$not_a_number') return false",
+    );
+}
+
+done_testing();

--- a/t/44-number-colors.t
+++ b/t/44-number-colors.t
@@ -1,0 +1,66 @@
+use strict;
+use warnings;
+use Test::More tests => 4;
+
+BEGIN {
+    delete $ENV{ANSI_COLORS_DISABLED};
+    delete $ENV{DATAPRINTERRC};
+    use File::HomeDir::Test;  # avoid user's .dataprinter
+    use_ok ('Term::ANSIColor');
+    use_ok ('Data::Printer', colored => 1);
+};
+
+pass('Loaded ok');
+
+my $data = {
+    not_a_number_1 => "0123",
+    not_a_number_2 => "Inf",
+    not_a_number_3 => "Infinity",
+    not_a_number_4 => "NaN",
+    not_a_number_5 => "0 but true",
+    not_a_number_6 => "-0123",
+    not_a_number_7 => "+0123",
+    not_a_number_8 => "",
+    not_a_number_9 => "abc",
+    not_a_number_10 => "+1",
+    not_a_number_11 => '1_000',
+
+    number_1 => 123,
+    number_2 => 0,
+    number_3 => 1,
+    number_4 => -1,
+    number_7 => 1.23,
+    number_8 => 1.23e+38,
+    number_9 => 1.23e-38,
+};
+
+my $space = ' 'x4;
+
+my $expected_output = color('reset') . "\\ {\n"
+    . ' 'x4 . colored('not_a_number_1', 'magenta') . ' 'x4 . '"' . colored('0123', 'bright_yellow') . '",' . "\n"
+    . ' 'x4 . colored('not_a_number_2', 'magenta') . ' 'x4 . '"' . colored("Inf", 'bright_yellow') . '",' . "\n"
+    . ' 'x4 . colored('not_a_number_3', 'magenta') . ' 'x4 . '"' . colored("Infinity", 'bright_yellow') . '",' . "\n"
+    . ' 'x4 . colored('not_a_number_4', 'magenta') . ' 'x4 . '"' . colored("NaN", 'bright_yellow') . '",' . "\n"
+    . ' 'x4 . colored('not_a_number_5', 'magenta') . ' 'x4 . '"' . colored("0 but true", 'bright_yellow') . '",' . "\n"
+    . ' 'x4 . colored('not_a_number_6', 'magenta') . ' 'x4 . '"' . colored("-0123", 'bright_yellow') . '",' . "\n"
+    . ' 'x4 . colored('not_a_number_7', 'magenta') . ' 'x4 . '"' . colored("+0123", 'bright_yellow') . '",' . "\n"
+    . ' 'x4 . colored('not_a_number_8', 'magenta') . ' 'x4 . '"' . colored("", 'bright_yellow') . '",' . "\n"
+    . ' 'x4 . colored('not_a_number_9', 'magenta') . ' 'x4 . '"' . colored("abc", 'bright_yellow') . '",' . "\n"
+    . ' 'x4 . colored('not_a_number_10', 'magenta') . ' 'x3 . '"' . colored("+1", 'bright_yellow') . '",' . "\n"
+    . ' 'x4 . colored('not_a_number_11', 'magenta') . ' 'x3 . '"' . colored('1_000', 'bright_yellow') . '",' . "\n"
+
+    . ' 'x4 . colored('number_1', 'magenta') . ' 'x10 . colored(123, 'bright_blue') . ",\n"
+    . ' 'x4 . colored('number_2', 'magenta') . ' 'x10 . colored(0, 'bright_blue') . ",\n"
+    . ' 'x4 . colored('number_3', 'magenta') . ' 'x10 . colored(1, 'bright_blue') . ",\n"
+    . ' 'x4 . colored('number_4', 'magenta') . ' 'x10 . colored(-1, 'bright_blue') . ",\n"
+    . ' 'x4 . colored('number_7', 'magenta') . ' 'x10 . colored(1.23, 'bright_blue') . ",\n"
+    . ' 'x4 . colored('number_8', 'magenta') . ' 'x10 . colored(1.23e+38, 'bright_blue') . ",\n"
+    . ' 'x4 . colored('number_9', 'magenta') . ' 'x10 . colored(1.23e-38, 'bright_blue') . "\n"
+    . "}"
+    ;
+
+is(
+    p($data),
+    $expected_output,
+    "Numbers and strings are written as expected",
+);


### PR DESCRIPTION
Here is the sample script:

``` perl
#!/usr/bin/perl

use DDP;

my $data = {
    not_a_number_1 => "0123",
    not_a_number_2 => "Inf",
    not_a_number_3 => "Infinity",
    not_a_number_4 => "NaN",
    not_a_number_5 => "0 but true",
    not_a_number_6 => "-0123",
    not_a_number_7 => "+0123",
    not_a_number_10 => "",
    not_a_number_11 => "abc",
    not_a_number_12 => "+1",
    not_a_number_13 => '1_000',

    number_1 => 123,
    number_2 => 0,
    number_3 => 1,
    number_4 => -1,
    number_7 => 1.23,
    number_8 => 1.23e+38,
    number_9 => 1.23e-38,
};

p $data;
```

Current version of Data::Printer output is this way:

![before](https://f.cloud.github.com/assets/47263/513930/ce75a2da-be4b-11e2-8415-8e6e838fdf72.png)

After this path the output is bit more accurate:

![after](https://f.cloud.github.com/assets/47263/513936/f26db768-be4b-11e2-8f5d-8b014f492915.png)

Actually this is not perfect solution, but it is better than the current situation so I have decided to propose this patch.

There is still problems with very large numbers and very small ones. That thing are not numbers, but Data::Printer output them as is they are numbers:

``` perl
my $data = { 
    not_a_number_1 => "123"x20,
    not_a_number_2 => ("0." . "0"x20 . "1"),
};
```
