### PR TITLE
Fixing whitespaces errors

### DIFF
--- a/examples/try_me.pl
+++ b/examples/try_me.pl
@@ -36,4 +36,3 @@ $sample{ref} = \%sample;
 weaken $sample{ref};
 
 use DDP; p %sample;
-

--- a/lib/DDP.pm
+++ b/lib/DDP.pm
@@ -30,4 +30,3 @@ Happy debugging!
 =head1 SEE ALSO
 
 L<Data::Printer>
-

--- a/lib/Data/Printer.pm
+++ b/lib/Data/Printer.pm
@@ -287,7 +287,7 @@ sub _p {
             }
         }
     }
-    
+
     if ( not $found ) {
         # if it's not a class and not a known core type, we must be in
         # a future perl with some type we're unaware of
@@ -700,7 +700,7 @@ sub GLOB {
 sub _unknown {
     my($item, $p) = @_;
     my $ref = ref $item;
-    
+
     my $string = '';
     $string = colored($ref, $p->{color}->{'unknown'});
     return $string;
@@ -1096,7 +1096,7 @@ Want to see what's inside a variable in a complete, colored
 and human-friendly way?
 
   use Data::Printer;   # or just "use DDP" for short
-  
+
   p @array;            # no need to pass references
 
 Code above might output something like this (with colors!):
@@ -1890,7 +1890,7 @@ To turn Data::Printer's output into HTML, you can do something like:
 
   use HTML::FromANSI;
   use Data::Printer;
-  
+
   my $html_output = ansi2html( p($object, colored => 1) );
 
 In the example above, the C<$html_output> variable contains the
@@ -2170,6 +2170,3 @@ RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A
 FAILURE OF THE SOFTWARE TO OPERATE WITH ANY OTHER SOFTWARE), EVEN IF
 SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
 SUCH DAMAGES.
-
-
-

--- a/lib/Data/Printer/Filter.pm
+++ b/lib/Data/Printer/Filter.pm
@@ -106,7 +106,7 @@ Create your filter module:
   filter 'SCALAR', sub {
       my ($ref, $properties) = @_;
       my $val = $$ref;
-      
+
       if ($val > 100) {
           return 'too big!!';
       }
@@ -362,5 +362,3 @@ Copyright 2011 Breno G. de Oliveira C<< <garu at cpan.org> >>. All rights reserv
 
 This module is free software; you can redistribute it and/or modify it
 under the same terms as Perl itself. See L<perlartistic>.
-
-

--- a/lib/Data/Printer/Filter/DB.pm
+++ b/lib/Data/Printer/Filter/DB.pm
@@ -9,7 +9,7 @@ filter 'DBI::db', sub {
     my $name = $dbh->{Driver}{Name};
 
     my $string = "$name Database Handle ("
-               . ($dbh->{Active} 
+               . ($dbh->{Active}
                   ? colored('connected', 'bright_green')
                   : colored('disconnected', 'bright_red'))
                . ') {'
@@ -45,7 +45,7 @@ filter 'DBI::st', sub {
     if ($sth->{NUM_OF_PARAMS} > 0) {
         my $values = $sth->{ParamValues};
         if ($values) {
-            $str .= '  (' 
+            $str .= '  ('
                  . join(', ',
                       map {
                          my $v = $values->{$_};
@@ -182,5 +182,3 @@ C<bindings unavailable> message instead of the bound values.
 =head1 SEE ALSO
 
 L<Data::Printer>
-
-

--- a/lib/Data/Printer/Filter/DateTime.pm
+++ b/lib/Data/Printer/Filter/DateTime.pm
@@ -163,5 +163,3 @@ please let us know.
 =head1 SEE ALSO
 
 L<Data::Printer>
-
-

--- a/lib/Data/Printer/Filter/Digest.pm
+++ b/lib/Data/Printer/Filter/Digest.pm
@@ -141,5 +141,3 @@ the hexdigest of a new, empty object of that same class.
 =head1 SEE ALSO
 
 L<Data::Printer>
-
-

--- a/t/01-p.t
+++ b/t/01-p.t
@@ -274,7 +274,7 @@ $regex = qr{
       |
     ^ \s* go \s
 }x;
-is( p($regex), '\ 
+is( p($regex), '\
       |
     ^ \s* go \s
   (modifiers: x)', 'creepy regex' );

--- a/t/05-obj.t
+++ b/t/05-obj.t
@@ -105,7 +105,7 @@ is( p($obj, class => { show_methods => 'all' }), 'Foo  {
     }
 }', 'testing objects (explicitly asking for all methods)' );
 
-is( p($obj, class => { internals => 0 } ), 
+is( p($obj, class => { internals => 0 } ),
 'Foo  {
     Parents       Bar
     public methods (4) : baz, borg, foo, new

--- a/t/06-obj2.t
+++ b/t/06-obj2.t
@@ -32,7 +32,7 @@ is( p($scalar), 'FooScalar  {
     internals: 42
 }', 'testing blessed scalar' );
 
-is( p($array ), 
+is( p($array ),
 'FooArray  {
     public methods (2) : foo, new
     private methods (0)
@@ -42,7 +42,7 @@ is( p($array ),
 SKIP: {
     skip 'no internals in blessed subs yet', 1;
 
-is( p($code), 
+is( p($code),
 'FooCode  {
     public methods (2) : foo, new
     private methods (0)

--- a/t/13.2-filter_db.t
+++ b/t/13.2-filter_db.t
@@ -130,4 +130,3 @@ sub cleanup {
 }
 
 done_testing;
-

--- a/t/13.3-filter_digest.t
+++ b/t/13.3-filter_digest.t
@@ -18,7 +18,7 @@ use Data::Printer {
 my $data = 'I can has Digest?';
 
 foreach my $module (qw( Digest::Adler32 Digest::MD2 Digest::MD4 Digest::MD5
-                        Digest::SHA Digest::SHA1 
+                        Digest::SHA Digest::SHA1
                         Digest::Whirlpool
 )) {
 

--- a/t/20-handles.t
+++ b/t/20-handles.t
@@ -64,4 +64,3 @@ SKIP: {
 };
 
 done_testing();
-

--- a/t/33-end_separator.t
+++ b/t/33-end_separator.t
@@ -35,4 +35,3 @@ is(
     $end_comma_output,
     "Got correct structure with end_separator => 1 and separator => '--'",
 );
-

--- a/t/36-valign.t
+++ b/t/36-valign.t
@@ -21,5 +21,3 @@ q{\ {
 }},
   'colored alignment'
 );
-
-

--- a/t/41-yaml.t
+++ b/t/41-yaml.t
@@ -40,4 +40,3 @@ is p($data), '\ {
     ]
 }',
   'testing odd objects (YAML::Syck)';
-


### PR DESCRIPTION
I've used script `whiter examples lib xt t` from the module https://metacpan.org/module/Test::Whitespaces to fix all problems with whitespaces.

Here is the list of rules that Test::Whitespaces uses:

 * Each line ends with "\n" (including the last line)
 * For new lines "\n" is used (not "\r\n")
 * There are no ending spaces on the lines
 * 4 spaces are used instead of tabs
 * No empty lines in the end of file