### PR TITLE
Added support for displaying scalar's unicode flag

### DIFF
--- a/lib/Data/Printer.pm
+++ b/lib/Data/Printer.pm
@@ -39,6 +39,7 @@ my $properties = {
     'end_separator'  => 0,
     'show_tied'      => 1,
     'show_tainted'   => 1,
+    'show_unicode'   => 0,
     'show_weak'      => 1,
     'show_readonly'  => 0,
     'show_lvalue'    => 1,
@@ -70,6 +71,7 @@ my $properties = {
         'caller_info' => 'bright_cyan',
         'weak'        => 'cyan',
         'tainted'     => 'red',
+        'unicode'     => 'bright_yellow',
         'escaped'     => 'bright_red',
         'unknown'     => 'bright_yellow on_blue',
     },
@@ -331,6 +333,9 @@ sub SCALAR {
 
     $string .= ' ' . colored('(TAINTED)', $p->{color}->{'tainted'})
         if $p->{show_tainted} and Scalar::Util::tainted($$item);
+
+    $string .= ' ' . colored('(U)', $p->{color}->{'unicode'})
+        if $p->{show_unicode} and utf8::is_utf8($$item);
 
     $p->{_tie} = ref tied $$item;
 

--- a/t/26.7-unicode.t
+++ b/t/26.7-unicode.t
@@ -1,0 +1,33 @@
+use strict;
+use warnings;
+use Test::More;
+
+BEGIN {
+    delete $ENV{ANSI_COLORS_DISABLED};
+    delete $ENV{DATAPRINTERRC};
+    use File::HomeDir::Test;  # avoid user's .dataprinter
+    use_ok ('Term::ANSIColor');
+    use_ok (
+        'Data::Printer',
+            colored      => 1,
+            show_unicode => 1,
+    );
+};
+
+my $uni_str= "\x{2603}";
+my $ascii_str= "\x{ff}";
+
+is(
+    p($uni_str),
+    color('reset') . q["] . colored($uni_str, 'bright_yellow') . q["]
+                   . ' ' . colored('(U)', 'bright_yellow'),
+    'unicode scalar gets suffix'
+);
+
+is(
+    p($ascii_str),
+    color('reset') . q["] . colored($ascii_str, 'bright_yellow') . q["],
+    'ascii scalar without suffix'
+);
+
+done_testing;


### PR DESCRIPTION
This adds a config option 'show_unicode', and a color 'unicode'.
When a scalar has the unicode flag set, it will be displayed with
a trailing '(U)' after it.