### PR TITLE
Protect against DATAPRINTERRC affecting tests

### DIFF
--- a/t/20-handles.t
+++ b/t/20-handles.t
@@ -6,17 +6,18 @@ BEGIN {
     $ENV{ANSI_COLORS_DISABLED} = 1;
     delete $ENV{DATAPRINTERRC};
     use File::HomeDir::Test;  # avoid user's .dataprinter
-    use File::HomeDir;
-    use File::Spec;
-    use Test::More;
-    use Fcntl;
+}
 
-    use Data::Printer;
+use File::HomeDir;
+use File::Spec;
+use Test::More;
+use Fcntl;
 
-    $filename = File::Spec->catfile(
-        File::HomeDir->my_home, 'test_file.dat'
-    );
-};
+use Data::Printer;
+
+$filename = File::Spec->catfile(
+    File::HomeDir->my_home, 'test_file.dat'
+);
 
 if ( open $var, '>', $filename ) {
     my $str = p $var;

--- a/t/26.2-tainted_rc.t
+++ b/t/26.2-tainted_rc.t
@@ -6,6 +6,7 @@ use Test::More;
 my $file;
 BEGIN {
     delete $ENV{ANSI_COLORS_DISABLED};
+    delete $ENV{DATAPRINTERRC};
     use Term::ANSIColor;
     use File::HomeDir::Test;
     use File::HomeDir;

--- a/t/27-pass_through.t
+++ b/t/27-pass_through.t
@@ -4,6 +4,7 @@ use warnings;
 use Test::More;
 BEGIN {
     $ENV{ANSI_COLORS_DISABLED} = 1;
+    delete $ENV{DATAPRINTERRC};
     use File::HomeDir::Test;  # avoid user's .dataprinter
 };
 

--- a/t/35-vstrings.t
+++ b/t/35-vstrings.t
@@ -5,11 +5,10 @@ BEGIN {
     $ENV{ANSI_COLORS_DISABLED} = 1;
     delete $ENV{DATAPRINTERRC};
     use File::HomeDir::Test;  # avoid user's .dataprinter
-
-    use Test::More;
-    use Data::Printer;
-
 }
+
+use Test::More;
+use Data::Printer;
 
 plan skip_all => 'Older perls do not have VSTRING support' if $] < 5.010;
 my $scalar = v1.2.3;

--- a/t/36-valign.t
+++ b/t/36-valign.t
@@ -8,8 +8,9 @@ BEGIN {
     $ENV{ANSI_COLORS_DISABLED} = 1;
     delete $ENV{DATAPRINTERRC};
     use File::HomeDir::Test;  # avoid user's .dataprinter
-    use Data::Printer;
-};
+}
+
+use Data::Printer;
 
 my $var = { q[foo bar],2,3,4};
 

--- a/t/37-format.t
+++ b/t/37-format.t
@@ -5,11 +5,10 @@ BEGIN {
     $ENV{ANSI_COLORS_DISABLED} = 1;
     delete $ENV{DATAPRINTERRC};
     use File::HomeDir::Test;  # avoid user's .dataprinter
-
-    use Test::More;
-    use Data::Printer;
-
 }
+
+use Test::More;
+use Data::Printer;
 
 format TEST =
 .

--- a/t/38-lvalue.t
+++ b/t/38-lvalue.t
@@ -5,11 +5,10 @@ BEGIN {
     $ENV{ANSI_COLORS_DISABLED} = 1;
     delete $ENV{DATAPRINTERRC};
     use File::HomeDir::Test;  # avoid user's .dataprinter
-
-    use Test::More;
-    use Data::Printer;
-
 }
+
+use Test::More;
+use Data::Printer;
 
 my $scalar = \substr( "abc", 2);
 my $test_name = "LVALUE refs";


### PR DESCRIPTION
One or two tests needed a "delete $ENV{DATAPRINTERRC}" line and a few
more needed the "use Data::Printer" line moved out of the BEGIN block
with an existing delete() call for it to actually have an effect.

These were manifesting as test failures for me.