### PR TITLE
Add new .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+/MYMETA.json
+/MYMETA.yml
+/Makefile
+/blib/
+/pm_to_blib


### PR DESCRIPTION
This ignores the commonly generated files when running `perl Makefile.PL && make && make test && make install`.