### PR TITLE
Printing hash/list declarations

### DIFF
--- a/lib/Data/Printer.pm
+++ b/lib/Data/Printer.pm
@@ -142,8 +142,11 @@ sub import {
     no strict 'refs';
     *{"$caller\::$imported"} = $exported;
     *{"$caller\::np"} = \&np;
-    *{"$caller\::pa"} = \&pa;
-    *{"$caller\::ph"} = \&ph;
+
+    if ($properties->{use_shortcut}) {
+        *{"$caller\::pa"} = \&pa;
+        *{"$caller\::ph"} = \&ph;
+    }
 }
 
 
@@ -152,6 +155,7 @@ sub p (\[@$%&];%) {
 }
 
 sub ph (%) { &p(+{@_}) }
+
 sub pa (@) { &p(+[@_]) }
 
 sub np (\[@$%&];%) {

--- a/lib/Data/Printer.pm
+++ b/lib/Data/Printer.pm
@@ -142,12 +142,17 @@ sub import {
     no strict 'refs';
     *{"$caller\::$imported"} = $exported;
     *{"$caller\::np"} = \&np;
+    *{"$caller\::pa"} = \&pa;
+    *{"$caller\::ph"} = \&ph;
 }
 
 
 sub p (\[@$%&];%) {
     return _print_and_return( $_[0], _data_printer(!!defined wantarray, @_) );
 }
+
+sub ph (%) { &p(+{@_}) }
+sub pa (@) { &p(+[@_]) }
 
 sub np (\[@$%&];%) {
     my ($dump, $p) = _data_printer(1, @_);

--- a/t/46-pa-ph.t
+++ b/t/46-pa-ph.t
@@ -8,7 +8,7 @@ BEGIN {
     use File::HomeDir::Test;  # avoid user's .dataprinter
 };
 
-use Data::Printer qw'return_value dump';
+use Data::Printer qw'return_value dump use_shortcut 1';
 
 my $dh = ph my %hsh = qw'a b c d';
 my $da = pa my @arr = 1..4;

--- a/t/46-pa-ph.t
+++ b/t/46-pa-ph.t
@@ -1,0 +1,17 @@
+use strict;
+use warnings;
+use Test::More tests => 2;
+
+BEGIN {
+    $ENV{ANSI_COLORS_DISABLED} = 1;
+    delete $ENV{DATAPRINTERRC};
+    use File::HomeDir::Test;  # avoid user's .dataprinter
+};
+
+use Data::Printer qw'return_value dump';
+
+my $dh = ph my %hsh = qw'a b c d';
+my $da = pa my @arr = 1..4;
+
+isnt( $dh, 4, 'hash declaration dump' );
+isnt( $da, 4, 'array declaration dump' );


### PR DESCRIPTION
Hi

When using p() on %hash/@array declarations I got:
```perl
p my %h = qw(a b c d);
# prints: 4
``` 

This pull request proposes two optional functions("pa" and "ph") to print declarations as array or hash.
So one can print like this:
```perl
use DDP use_shortcut => 1;
ph my %hsh = qw(a b c d);
pa my @arr = 1..4;
```
```text
{
    a   "b",
    c   "d"
}
[
    [0] 1,
    [1] 2,
    [2] 3,
    [3] 4
]
```