### PR TITLE
Three fixes to prevent test failures on cpantesters.org

### DIFF
--- a/lib/Data/Printer.pm
+++ b/lib/Data/Printer.pm
@@ -12,7 +12,9 @@ use if $] < 5.010, 'Hash::Util::FieldHash::Compat' => qw(fieldhash);
 use File::Spec;
 use File::HomeDir ();
 use Fcntl;
-use version 0.77 ();
+# This causes strangeness wrt UNIVERSAL on Perl 5.8 with some versions of version.pm.
+# Instead, we now require version in the VSTRING() method.
+# use version 0.77 ();
 
 our $VERSION = '0.36';
 
@@ -637,7 +639,9 @@ sub Regexp {
 
 sub VSTRING {
     my ($item, $p) = @_;
+    eval { require version };
     my $string = '';
+    # This will raise an error if we have version < 0.77;
     $string .= colored(version->declare($$item)->normal, $p->{color}->{'vstring'});
     return $string;
 }

--- a/t/26.2-tainted_rc.t
+++ b/t/26.2-tainted_rc.t
@@ -15,6 +15,8 @@ BEGIN {
             File::HomeDir->my_home,
             '.dataprinter'
     );
+    # untaint - only necessary for old Win32
+    ($file) = $file =~ /^(.*)$/;
 
     if (-e $file) {
         plan skip_all => 'File .dataprinter should not be in test homedir';


### PR DESCRIPTION
These three commits are intended to address most of the current test failures on cpantesters.org, namely:

1. sporadic failures with perl 5.12 and later on OS X.
2. sporadic failures with 5.12 and later on older versions of Windows. (I was not actually able to reproduce the error on Windows, so the proposed test fix is something of a guess in this case).
3. frequent failures with perl 5.8 on all platforms.
