### PR TITLE
Document that Data::Printer::Filter::DB supports DBIx::Class.

### DIFF
--- a/lib/Data/Printer/Filter/DB.pm
+++ b/lib/Data/Printer/Filter/DB.pm
@@ -129,9 +129,13 @@ or, in your C<.dataprinter> file:
 
 =head1 DESCRIPTION
 
-This is a filter plugin for L<Data::Printer>. It filters through
-L<DBI>'s handlers (dbh) and statement (sth) objects displaying relevant
-information for the user.
+This is a filter plugin for L<Data::Printer>. It filters through L<DBI>'s
+handlers (dbh) and statement (sth) objects displaying relevant information for
+the user.  It also filters any object which inherits from
+L<DBIx::Class::Schema>, L<DBIx::Class::ResultSet> or
+L<DBIx::Class::ResultSetColumn>.
+
+=head2 DBI Sample Output
 
 L<DBI> is an extremely powerful and complete database interface. But
 it does a lot of magic under the hood, making their objects somewhat harder
@@ -182,7 +186,6 @@ exactly what you came for:
 Note that if your driver does not support holding of parameter values, you'll get a
 C<bindings unavailable> message instead of the bound values.
 
-
 =head1 SEE ALSO
 
-L<Data::Printer>
+L<Data::Printer>, L<Data::Printer::Filter>


### PR DESCRIPTION
This doesn't include any DBIx::Class sample output, but it does at least document that these objects are supported.