### PR TITLE
Fix testcase for new unicode feature

### DIFF
--- a/t/26.7-unicode.t
+++ b/t/26.7-unicode.t
@@ -10,6 +10,7 @@ BEGIN {
     use_ok (
         'Data::Printer',
             colored      => 1,
+            return_value => 'dump',
             show_unicode => 1,
     );
 };


### PR DESCRIPTION
The default return value of p() changed from "dump" to "pass" since
I originally wrote this.  I updated the testcase to specifically
request "dump", and it passes again.