### PR TITLE
Fix issue with dereferencing code refs.

### DIFF
--- a/lib/Data/Printer.pm
+++ b/lib/Data/Printer.pm
@@ -187,7 +187,7 @@ sub _print_and_return {
         elsif ($ref eq 'HASH') {
             return %{ $item };
         }
-        elsif ( grep { $ref eq $_ } qw(REF SCALAR CODE Regexp GLOB VSTRING) ) {
+        elsif ( grep { $ref eq $_ } qw(REF SCALAR Regexp GLOB VSTRING) ) {
             return $$item;
         }
         else {


### PR DESCRIPTION
Code refs cannot be dereferenced. In case of printing a code ref, the return value (return_value option)
should be the same code ref.
