### PR TITLE
Fix tests after perlblead 8bf4c4010cc474d4000c2a8c78f6890fa5f1e577

### DIFF
--- a/t/27-pass_through.t
+++ b/t/27-pass_through.t
@@ -18,11 +18,12 @@ eval { require Capture::Tiny; 1; }
 ##############
 ### hashes ###
 ##############
-my %foo = ( answer => 42 );
+my %foo = ( answer => 42, question => 24 );
 
 my $expected = <<'EOT';
 {
-    answer   42
+    answer     42,
+    question   24
 }
 EOT
 
@@ -44,7 +45,7 @@ is_deeply \%return_list, \%foo, 'pass-through return (hash list)';
 is $stdout, '', 'STDOUT should be empty after p() (hash, scalar)';
 is $stderr, $expected, 'pass-through STDERR (hash, scalar)';
 
-like $return_scalar, qr{^1/\d+$}, 'pass-through return (hash scalar)';
+is $return_scalar, scalar %foo, 'pass-through return (hash scalar)';
 
 
 ##############

--- a/t/27.2-pass_through.t
+++ b/t/27.2-pass_through.t
@@ -18,11 +18,12 @@ eval { require Capture::Tiny; 1; }
 ##############
 ### hashes ###
 ##############
-my %foo = ( answer => 42 );
+my %foo = ( answer => 42, question => 24 );
 
 my $expected = <<'EOT';
 {
-    answer   42
+    answer     42,
+    question   24
 }
 EOT
 
@@ -44,8 +45,7 @@ is_deeply \%return_list, \%foo, 'pass-through return (hash list)';
 is $stdout, '', 'STDOUT should be empty after p() (hash, scalar)';
 is $stderr, $expected, 'pass-through STDERR (hash, scalar)';
 
-like $return_scalar, qr{^1/\d+$}, 'pass-through return (hash scalar)';
-
+is $return_scalar, scalar %foo, 'pass-through return (hash scalar)';
 
 ##############
 ### arrays ###

--- a/t/27.3-pass_through-DDP.t
+++ b/t/27.3-pass_through-DDP.t
@@ -18,11 +18,12 @@ eval { require Capture::Tiny; 1; }
 ##############
 ### hashes ###
 ##############
-my %foo = ( answer => 42 );
+my %foo = ( answer => 42, question => 24 );
 
 my $expected = <<'EOT';
 {
-    answer   42
+    answer     42,
+    question   24
 }
 EOT
 
@@ -44,7 +45,7 @@ is_deeply \%return_list, \%foo, 'pass-through return (hash list)';
 is $stdout, '', 'STDOUT should be empty after p() (hash, scalar)';
 is $stderr, $expected, 'pass-through STDERR (hash, scalar)';
 
-like $return_scalar, qr{^1/\d+$}, 'pass-through return (hash scalar)';
+is $return_scalar, scalar %foo, 'pass-through return (hash scalar)';
 
 
 ##############

--- a/t/27.4-pass_through-DDP.t
+++ b/t/27.4-pass_through-DDP.t
@@ -18,11 +18,12 @@ eval { require Capture::Tiny; 1; }
 ##############
 ### hashes ###
 ##############
-my %foo = ( answer => 42 );
+my %foo = ( answer => 42, question => 24 );
 
 my $expected = <<'EOT';
 {
-    answer   42
+    answer     42,
+    question   24
 }
 EOT
 
@@ -44,7 +45,7 @@ is_deeply \%return_list, \%foo, 'pass-through return (hash list)';
 is $stdout, '', 'STDOUT should be empty after p() (hash, scalar)';
 is $stderr, $expected, 'pass-through STDERR (hash, scalar)';
 
-like $return_scalar, qr{^1/\d+$}, 'pass-through return (hash scalar)';
+is $return_scalar, scalar %foo, 'pass-through return (hash scalar)';
 
 
 ##############


### PR DESCRIPTION
Perl has changed return value for the (scalar %hash expression), and tests used regexp for that. Instead of changing it (depending on perl version), i've decided to use a direct (scalar %hash) comparison, so it'd always be a correct one.

I've added another key to the hash to avoid false-positives from the new return value being just 'any' true value and checking for the actual '2'.