### PR TITLE
Wrap stringification into eval

### DIFF
--- a/lib/Data/Printer.pm
+++ b/lib/Data/Printer.pm
@@ -270,9 +270,11 @@ sub _p {
 
     delete $p->{_reftype}; # abort override
 
-    # globs don't play nice
-    $ref = 'GLOB' if "$item" =~ /GLOB\([^()]+\)$/;
-
+    eval {
+        # globs don't play nice
+        $ref = 'GLOB' if "$item" =~ /GLOB\([^()]+\)$/;
+        1;
+    };
 
     # filter item (if user set a filter for it)
     my $found;


### PR DESCRIPTION
Hi, I faced the problem when object raises errors when you stringify it, so you can still add your own filter to print it safely, but this part in the printer should be wrapped, otherwise it will fail before even reaching filter.