### PR TITLE
simplify homedir logic, borrowing from File::HomeDir::Tiny

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,9 @@
 Revision history for Data-Printer
 
+    OTHER:
+        - simplified homedir logic for MSWin32, darwin and MacOS
+          (Karen Etheridge)
+
 0.99_020 2018-06-30
     NEW FEATURES:
         - new 'fulldump' option to ignore max string/array/hash.

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -31,6 +31,9 @@ my %options = (
 if ($^O =~ /Win32/i) {
     $options{PREREQ_PM}{'Win32::Console::ANSI'} = 1.0;
 }
+if ($^O eq 'MacOS') {
+    $options{PREREQ_PM}{'Mac::SystemDirectory'} = 0;
+}
 
 if ($ENV{DDPTESTCOVERAGE}) {
     foreach my $p (qw(


### PR DESCRIPTION
- darwin is just another breed of unix and $ENV{HOME} will always work.

- on MSWin32, $ENV{HOME} also works starting in 5.016; before that, use
$ENV{USERPROFILE}.

- (<~>)[0] should always work when $ENV{HOME} doesn't.

- Mac::SystemDirectory is only needed on MacOS (pre-OSX), which is
rarely seen in the wild, but we add Mac::SystemDirectory to the prereqs
on that platform so we can rely on its existence.