### PR TITLE
Remove `JSON::Parser` as a dependency for the test suite

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -40,7 +40,7 @@ if ($ENV{DDPTESTCOVERAGE}) {
         Date::Handler::Delta Date::Simple Date::Manip Panda::Date
         DateTime DateTime::Duration Mojolicious Class::Date Class::Date::Rel
         Digest::MD5 Digest::SHA Digest::MD2 Digest::MD4
-        JSON::PP JSON::XS JSON JSON::Any JSON::MaybeXS JSON::DWIW JSON::Parser
+        JSON::PP JSON::XS JSON JSON::Any JSON::MaybeXS JSON::DWIW
         JSON::SL Pegex::JSON Cpanel::JSON::XS JSON::Tiny JSON::Typist Dancer
         Dancer2 HTTP::Message
     )) {


### PR DESCRIPTION
`JSON::Parser` is no longer available on CPAN. It was removed from the [`JSON`](https://metacpan.org/pod/JSON) module in 2010, see [this](https://metacpan.org/changes/release/MAKAMAKA/JSON-2.23) Changelog. Including it as a dependency for the test suite can cause the travis test to install the `JSON` module version 1.15 from 2007 (which includes `JSON::Parser` as a sub module). Incidentally this also installs an old version of `JSON::PP` (also included in the 2007 version of the `JSON` module) which can prevent the installation of a newer version of `JSON::PP` which again can cause test failures (see e.g. test `t/104-filter_web.t`) since the tests expect a newer version of `JSON::PP` to be installed.

I am curious if this patch will solve the [failed test](https://travis-ci.org/github/garu/Data-Printer/builds/709199155) in PR #147 or if there is something else going on.
