### PR TITLE
Typo in pod, a link was broken

### DIFF
--- a/lib/Data/Printer.pm
+++ b/lib/Data/Printer.pm
@@ -689,7 +689,7 @@ This means you could have the following in one of your classes:
 Notice that B<< you can do this without adding Data::Printer as a dependency >>
 to your project! Just write your sub and it will be called with the object to
 be printed and a C<$ddp> object ready for you. See
-L<< Data::Printer::Object|/Data::Printer::Object/"Methods and Accessors for Filter Writers" >>
+L<< Data::Printer::Object|Data::Printer::Object/"Methods and Accessors for Filter Writers" >>
 for how to use it to pretty-print your data.
 
 Finally, if your object implements string overload or provides a method called


### PR DESCRIPTION
I was just reviewing the new things in documentation and found a "broken link" (since I read the doc in a browser). Hope it helps!