### PR TITLE
Issue 158 - DBIC resultset filter

### DIFF
--- a/lib/Data/Printer/Filter/DB.pm
+++ b/lib/Data/Printer/Filter/DB.pm
@@ -201,8 +201,8 @@ filter 'DBIx::Class::ResultSet' => sub {
             $attrs = { %{ $rs->_resolved_attrs } }; 1;
         } && ref $attrs eq 'HASH'
     ) {
-        if (exists $attrs->{where} && keys %{$attrs->{where}}) {
-            $output .= $ddp->parse($attrs->{where});
+        if (exists $attrs->{where}) {
+            $output .= $ddp->parse($attrs->{where})
         }
         else {
             $output .= '-';
@@ -224,8 +224,12 @@ filter 'DBIx::Class::ResultSet' => sub {
                 ;
         if (@query_data) {
             $output .= $ddp->newline . join( $ddp->newline, map {
-                    $_->[1] . ' ' . $ddp->maybe_colorize('(', 'brackets')
-                    . $_->[0]{sqlt_datatype} . $ddp->maybe_colorize(')', 'brackets')
+                    my $bound = $_->[1];
+                    if ($_->[0]{sqlt_datatype}) {
+                      $bound .= ' ' . $ddp->maybe_colorize('(', 'brackets')
+                        . $_->[0]{sqlt_datatype} . $ddp->maybe_colorize(')', 'brackets');
+                    }
+                    $bound
                   } @query_data
                 );
         }

--- a/t/101-filter_db.t
+++ b/t/101-filter_db.t
@@ -499,5 +499,15 @@ q|User ResultSource {
     user_id:     1
 }), 'db entry with extra col');
     # TODO: test some ->all() with prefetch
+    #
+    my $arrayrefref = $schema->resultset('User')->search(\[ 'email REGEXP ?' => 'gmail']);
+    is ($ddp->parse($arrayrefref), 'User ResultSet {
+    current search parameters: \[ 
+         [0] "email REGEXP ?"
+         [1] "gmail"
+    ]
+    as query:
+        (SELECT me.user_id, me.identity, me.email, me.city, me.state, me.code1, me.created FROM user me)
+}', 'empty resultset');
     };
 }

--- a/t/101-filter_db.t
+++ b/t/101-filter_db.t
@@ -1,6 +1,6 @@
 use strict;
 use warnings;
-use Test::More tests => 23;
+use Test::More tests => 24;
 use Data::Printer::Object;
 
 test_dbi();
@@ -502,12 +502,13 @@ q|User ResultSource {
     #
     my $arrayrefref = $schema->resultset('User')->search(\[ 'email REGEXP ?' => 'gmail']);
     is ($ddp->parse($arrayrefref), 'User ResultSet {
-    current search parameters: \[ 
-         [0] "email REGEXP ?"
-         [1] "gmail"
+    current search parameters: [
+        [0] "email REGEXP ?",
+        [1] "gmail"
     ]
     as query:
-        (SELECT me.user_id, me.identity, me.email, me.city, me.state, me.code1, me.created FROM user me)
-}', 'empty resultset');
+        (SELECT me.user_id, me.identity, me.email, me.city, me.state, me.code1, me.created FROM user me WHERE ( email REGEXP ? ))
+        gmail
+}', 'literal sql with bind params');
     };
 }


### PR DESCRIPTION
this should close #158. Basically, it just removes the empty hash check for the
where attr in the ResultSet, allowing it to be anything.

In addition, when using literal SQL, you could skimp on the sqlt_datatype, so I
made the code check against that
