### PR TITLE
[doc] Clarify the scalar_quotes option

### DIFF
--- a/lib/Data/Printer/Object.pm
+++ b/lib/Data/Printer/Object.pm
@@ -868,6 +868,8 @@ option defines which part of the string to preserve. Can be set to 'begin',
 
 Which quotation character to use when printing strings (default: ")
 
+Can be set to 0 (never quote).
+
 =head3 escape_chars
 
 Use this to escape certain characters from strings, which could be useful if


### PR DESCRIPTION
Quoting of strings can be disabled as follows in `.dataprinter` (or similarly in code)

```
scalar_quotes = 0
```

See also:
https://metacpan.org/pod/Data::Printer::Object#quote_keys