### PR TITLE
initial "show_numbers_strict" to display stringified numbers as strin…

### DIFF
--- a/lib/Data/Printer/Filter/SCALAR.pm
+++ b/lib/Data/Printer/Filter/SCALAR.pm
@@ -3,6 +3,7 @@ use strict;
 use warnings;
 use Data::Printer::Filter;
 use Scalar::Util;
+use B;
 
 filter 'SCALAR' => \&parse;
 filter 'LVALUE' => sub {
@@ -26,7 +27,12 @@ sub parse {
     elsif ( $ddp->show_dualvar ne 'off' ) {
         my $numified;
         $numified = do { no warnings 'numeric'; 0+ $value } if defined $value;
-        if ( $numified ) {
+        if ( $numified && $ddp->show_numbers_strict eq 'on' && ! _is_number_strict( $value ) ) {
+            $ret = Data::Printer::Common::_process_string( $ddp, "$value", 'string' );
+            $ret = _quoteme($ddp, $ret);
+            $ret .= ' (dualvar: ' . $ddp->maybe_colorize( $numified, 'number' ) . ')';
+        }
+        elsif ( $numified ) {
             if ( "$numified" eq $value
                 || (
                     # lax mode allows decimal zeroes
@@ -120,6 +126,11 @@ sub _is_number {
     /x;
 
     return $is_number;
+}
+
+sub _is_number_strict {
+    my ($maybe_a_number) = @_;
+    return (0 != (B::svref_2object(\$maybe_a_number)->FLAGS & B::SVf_POK)) ? 0 : 1;
 }
 
 1;

--- a/lib/Data/Printer/Object.pm
+++ b/lib/Data/Printer/Object.pm
@@ -70,7 +70,7 @@ my @method_names =qw(
     hash_preserve unicode_charnames colored theme show_weak
     max_depth index separator end_separator class_method class hash_separator
     align_hash sort_keys quote_keys deparse return_value show_dualvar show_tied
-    warnings arrows coderef_stub coderef_undefined
+    warnings arrows coderef_stub coderef_undefined show_numbers_strict
 );
 foreach my $method_name (@method_names) {
     no strict 'refs';
@@ -228,6 +228,13 @@ sub _init {
         $self->{caller_info} = 1;
         $self->{caller_message} = $msg;
     }
+
+    $self->{'show_numbers_strict'} = Data::Printer::Common::_fetch_anyof(
+        $props,
+        'show_numbers_strict',
+        'off',
+        [qw(on off)]
+    );
 
     $self->multiline(
         Data::Printer::Common::_fetch_scalar_or_default($props, 'multiline', 1)
@@ -897,7 +904,6 @@ or 'false'. If you have more than one of those in your data, Data::Printer
 will by default print the second one as a circular reference. When this option
 is set to true, it will instead resolve the scalar value and keep going. (default: false)
 
-
 =head2 Array Options
 
 =head3 array_max
@@ -923,8 +929,7 @@ or 'end'. (default: 'begin')
 
 When set, shows the index number before each array element. (default: 1)
 
-
-=head4 Hash Options
+=head2 Hash Options
 
 =head3 align_hash
 


### PR DESCRIPTION
…gs ie. "10" and numbers as numbers ie. 10

# Example1: show_numbers_strict => "on" -- prints 11 as 11 and  prints "11" as "11"

$ perl -Ilib -e 'use DDP show_numbers_strict => "on"; my $a = 11; p $a; $a = "11"; p $a;'
Printing in line 1 of -e:
11
Printing in line 1 of -e:
"11" (dualvar: 11)


# Example2: show_numbers_strict => "off" by default

$ perl -Ilib -e 'use DDP; my $a = 11; p $a; $a = "11"; p $a;'
Printing in line 1 of -e:
11
Printing in line 1 of -e:
11
