### PR TITLE
Remove seen entries when their object is destroyed

### DIFF
--- a/lib/Data/Printer/Filter/ARRAY.pm
+++ b/lib/Data/Printer/Filter/ARRAY.pm
@@ -79,13 +79,13 @@ sub parse {
         my $ref = ref $array_ref->[$idx];
         if ($ref) {
             if ($ref eq 'SCALAR') {
-                $string .= $ddp->parse(\$array_ref->[$idx]);
+                $string .= $ddp->parse(\$array_ref->[$idx], tied_parent => !!$tied);
             }
             elsif ($ref eq 'REF') {
-                $string .= $ddp->parse(\$array_ref->[$idx]);
+                $string .= $ddp->parse(\$array_ref->[$idx], tied_parent => !!$tied);
             }
             else {
-                $string .= $ddp->parse($array_ref->[$idx]);
+                $string .= $ddp->parse($array_ref->[$idx], tied_parent => !!$tied);
             }
         }
         else {

--- a/lib/Data/Printer/Filter/HASH.pm
+++ b/lib/Data/Printer/Filter/HASH.pm
@@ -94,12 +94,12 @@ sub parse {
         # a '\' in front of them.
         my $ref = ref $hash_ref->{$key->{raw}};
         if ( $ref && $ref eq 'SCALAR' ) {
-            $string .= $ddp->parse(\$hash_ref->{ $key->{raw} });
+            $string .= $ddp->parse(\$hash_ref->{ $key->{raw} }, tied_parent => !!$tied);
         }
         elsif ( $ref && $ref ne 'REF' ) {
-            $string .= $ddp->parse( $hash_ref->{ $key->{raw} });
+            $string .= $ddp->parse( $hash_ref->{ $key->{raw} }, tied_parent => !!$tied);
         } else {
-            $string .= $ddp->parse(\$hash_ref->{ $key->{raw} });
+            $string .= $ddp->parse(\$hash_ref->{ $key->{raw} }, tied_parent => !!$tied);
         }
 
         $string .= $ddp->maybe_colorize($ddp->separator, 'separator')

--- a/lib/Data/Printer/Object.pm
+++ b/lib/Data/Printer/Object.pm
@@ -48,6 +48,7 @@ package # hide from pause
 
 package Data::Printer::Object;
 use Scalar::Util ();
+use Hash::Util::FieldHash ();
 use Data::Printer::Theme;
 use Data::Printer::Filter::SCALAR; # also implements LVALUE
 use Data::Printer::Filter::ARRAY;
@@ -587,12 +588,13 @@ sub _filters_for_data {
 sub _see {
     my ($self, $data, %options) = @_;
     return {} unless ref $data;
-    my $id = pack 'J', Scalar::Util::refaddr($data);
+    my $id = Hash::Util::FieldHash::id($data);
     if (!exists $self->{_seen}{$id}) {
         $self->{_seen}{$id} = {
             name     => $self->current_name,
             refcount => ($self->show_refcount ? $self->_refcount($data) : 0),
         };
+        Hash::Util::FieldHash::register($data, $self->{_seen}) if $options{tied_parent};
         return { refcount => $self->{_seen}{$id}->{refcount} };
     }
     return { refcount => $self->{_seen}{$id}->{refcount} } if $options{seen_override};
@@ -601,7 +603,7 @@ sub _see {
 
 sub seen {
     my ($self, $data) = @_;
-    my $id = pack 'J', Scalar::Util::refaddr($data);
+    my $id = Hash::Util::FieldHash::id($data);
     return exists $self->{_seen}{$id};
 }
 
@@ -609,7 +611,7 @@ sub unsee {
     my ($self, $data) = @_;
     return unless ref $data && keys %{$self->{_seen}};
 
-    my $id = pack 'J', Scalar::Util::refaddr($data);
+    my $id = Hash::Util::FieldHash::id($data);
     delete $self->{_seen}{$id};
     return;
 }


### PR DESCRIPTION
The code was previously assuming refaddrs would never be reused, however this not true when dealing with tied hashes (because the values they return are temporaries). This avoids this problem by using a piece of fieldhash infrastructure to delete entries from the seen hash when the associated object is destroyed.

Using a fieldhash would have been the easiest solution but due to a bug in how its implementation deals with objects that have string overloading we can't use that here.

This branch does bump the minimum perl to 5.10, unless we use `Hash::Util::FieldHash::Compat` instead.

This fixes #170