### PR TITLE
Fix '_dataprinter' typo in lib/Data/Printer/Object.pm

### DIFF
--- a/lib/Data/Printer/Object.pm
+++ b/lib/Data/Printer/Object.pm
@@ -1168,7 +1168,7 @@ option to 0.
 =head3 class_method
 
 When Data::Printer is printing an object, it first looks for a method
-named "C<_dataprinter>" and, if one is found, we call it instead of actually
+named "C<_data_printer>" and, if one is found, we call it instead of actually
 parsing the structure.
 
 This way, module authors can control how Data::Printer outputs their objects


### PR DESCRIPTION
It took me a little bit to get my code working as I wanted because I didn't read the main doc for Data::Printer, which mentions the correct method name '_data_printer', but the Data::Printer::Object doc with a missing underscore.

Great module!